### PR TITLE
Explicitly import pkg_resources in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ XStatic - setup.py
 import os
 
 from setuptools import setup, find_packages
+import pkg_resources
 
 # The README.txt file should be written in reST so that PyPI can use
 # it to generate your project's PyPI page. 


### PR DESCRIPTION
Since recent versions of setuptools no longer impiort pkg_resources internally, and the xstatic namespace mechanism relies on that package being imported, we need to explicitly import it in setup.py now, otherwise we can randomly get failures when installing multiple xstatic packages as dependencies, depending on the order in which pypi decides to install them.